### PR TITLE
.ORG directive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs6502"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Simon Whitehead <chemnova@gmail.com>"]
 repository = "https://github.com/simon-whitehead/rs6502"
 description = "A 6502 Microprocessor tool suite. Includes a Disassembler, Assembler and Emulator."

--- a/src/assembler/assembler.rs
+++ b/src/assembler/assembler.rs
@@ -389,9 +389,31 @@ mod tests {
                              None)
             .unwrap();
 
-        println!("SEGMENTS: {:?}", segments);
-
         assert_eq!(0xC000, segments[0].address);
         assert_eq!(0x0100, segments[1].address);
+    }
+
+    #[test]
+    fn can_jump_between_code_segments() {
+        let mut assembler = Assembler::new();
+        let segments = assembler.assemble_string("
+            .ORG $C000
+            JMP CALLBACK
+
+            .ORG $2000
+            LDA #$AA
+            STA $2001
+
+            CALLBACK
+            LDX #$0A
+        ",
+                             None)
+            .unwrap();
+
+        assert_eq!(0xC000, segments[0].address);
+        assert_eq!(0x2000, segments[1].address);
+
+        assert_eq!(0x05, segments[0].code[0x01]);
+        assert_eq!(0x20, segments[0].code[0x02]);
     }
 }

--- a/src/assembler/assembler.rs
+++ b/src/assembler/assembler.rs
@@ -129,6 +129,7 @@ impl Assembler {
                     address: org_addr,
                     code: Vec::new(),
                 };
+                addr = org_addr;
             } else if let ParserToken::RawByte(byte) = token {
                 // Push raw bytes directly into the output
                 current_segment.code.push(byte);

--- a/src/assembler/lexer.rs
+++ b/src/assembler/lexer.rs
@@ -445,4 +445,23 @@ mod tests {
                      LexerToken::CloseParenthesis],
                    &tokens[1][..]);
     }
+
+    #[test]
+    fn can_handle_directives() {
+        let mut lexer = Lexer::new();
+        let tokens = lexer.lex_string("
+            .ORG $C000
+            LDA #$FF
+        ")
+            .unwrap();
+
+        assert_eq!(&[LexerToken::Period,
+                     LexerToken::Ident("ORG".into()),
+                     LexerToken::Address("C000".into())],
+                   &tokens[1][..]);
+
+        assert_eq!(&[LexerToken::Ident("LDA".into()),
+                     LexerToken::Immediate("FF".into(), ImmediateBase::Base16)],
+                   &tokens[2][..]);
+    }
 }

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -4,6 +4,6 @@ mod token;
 mod lexer;
 mod parser;
 
-pub use self::assembler::Assembler;
+pub use self::assembler::{Assembler, CodeSegment};
 pub use self::token::LexerToken;
 pub use self::lexer::Lexer;

--- a/src/assembler/parser.rs
+++ b/src/assembler/parser.rs
@@ -168,8 +168,6 @@ impl Parser {
                     let directive = directive.to_uppercase();
                     match &directive[..] {
                         "ORG" => {
-                            // TODO: Consume all tokens after this as raw tokens and
-                            //       have the Assembler decide how to handle them
                             result.push(self.consume_org_directive(&mut peeker)?);
                         }
                         _ => return Err(ParserError::unknown_identifier(self.line)),

--- a/src/assembler/token.rs
+++ b/src/assembler/token.rs
@@ -26,5 +26,5 @@ pub enum ParserToken {
     OpCode(OpCode),
     Absolute(String),
     RawByte(u8),
-    Directive(String),
+    OrgDirective(u16),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ mod disassembler;
 mod cpu;
 mod opcodes;
 
-pub use assembler::Assembler;
+pub use assembler::{Assembler, CodeSegment};
 pub use cpu::{Cpu, CpuError, CpuStepResult};
 pub use disassembler::Disassembler;
 pub use opcodes::OpCode;

--- a/tests/assembly.rs
+++ b/tests/assembly.rs
@@ -9,8 +9,10 @@ fn INTEGRATION_ASSEMBLY_can_assemble_disassemble_basic_opcodes() {
     let mut assembler = rs6502::Assembler::new();
     let disassembler = rs6502::Disassembler::with_code_only();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    let disassembled = rs6502::Disassembler::clean_asm(disassembler.disassemble(&bytecode));
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    println!("Found {} segments", segments.len());
+    let disassembled =
+        rs6502::Disassembler::clean_asm(disassembler.disassemble(&segments[0].code[..]));
 
     assert_eq!(asm, disassembled.join("\n"));
 }
@@ -31,8 +33,8 @@ fn INTEGRATION_ASSEMBLY_can_assemble_disassemble_clearmem_implementation() {
     let mut assembler = rs6502::Assembler::new();
     let disassembler = rs6502::Disassembler::with_code_only();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    let disassembled = rs6502::Disassembler::clean_asm(disassembler.disassemble(&bytecode));
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    let disassembled = rs6502::Disassembler::clean_asm(disassembler.disassemble(&segments[0].code));
 
     let clean_disassembled = disassembled.join("\n");
 

--- a/tests/cpu_integration.rs
+++ b/tests/cpu_integration.rs
@@ -742,3 +742,27 @@ fn INTEGRATION_CPU_sbc_with_decimal_mode() {
 
     assert_eq!(0x15, cpu.registers.A);
 }
+
+#[test]
+fn INTEGRATION_CPU_can_load_code_segments_at_offsets() {
+    let asm = "
+        .ORG $2000
+        LDA #$35
+        STA $4000
+
+        .ORG $ABCD
+        LDA #$00
+        STA $0100
+    ";
+
+    let mut cpu = rs6502::Cpu::new();
+    let mut assembler = rs6502::Assembler::new();
+
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    for segment in segments {
+        cpu.load(&segment.code[..], segment.address);
+    }
+
+    assert_eq!(&[0xA9, 0x35, 0x8D, 0x00, 0x40], &cpu.memory[0x2000..0x2005]);
+    assert_eq!(&[0xA9, 0x00, 0x8D, 0x00, 0x01], &cpu.memory[0xABCD..0xABD2]);
+}

--- a/tests/cpu_integration.rs
+++ b/tests/cpu_integration.rs
@@ -11,8 +11,8 @@ fn INTEGRATION_CPU_can_add_basic_numbers_in_accumulator() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(2);
 
@@ -30,8 +30,8 @@ fn INTEGRATION_CPU_can_add_binary_coded_decimal_numbers_in_accumulator() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(3);
 
@@ -48,8 +48,8 @@ fn INTEGRATION_CPU_can_add_mixed_mode_numbers_in_accumulator() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(2);
 
@@ -68,8 +68,8 @@ fn INTEGRATION_CPU_can_store_bytes_in_memory() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(4);
 
@@ -90,8 +90,8 @@ fn INTEGRATION_CPU_can_overwrite_own_memory() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(4);
 
@@ -110,8 +110,8 @@ fn INTEGRATION_CPU_can_load_byte_into_memory_and_logical_AND_it_with_A_register(
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(4);
 
@@ -133,8 +133,8 @@ fn INTEGRATION_CPU_can_load_byte_into_memory_and_logical_AND_it_with_A_register_
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(4);
 
@@ -154,8 +154,8 @@ fn INTEGRATION_CPU_does_not_branch_on_clear_carry_flag() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(3);
 
@@ -175,8 +175,8 @@ fn INTEGRATION_CPU_can_branch_on_carry_flag() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(4);
 
@@ -201,8 +201,8 @@ fn INTEGRATION_CPU_can_branch_on_carry_flag_to_correct_offset() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(5);
 
@@ -221,8 +221,8 @@ fn INTEGRATION_CPU_can_loop_on_bcc() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(30);
 
@@ -242,8 +242,8 @@ fn INTEGRATION_CPU_can_branch_on_bcs() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(30);
 
@@ -263,8 +263,8 @@ fn INTEGRATION_CPU_can_branch_on_beq() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(30);
 
@@ -284,8 +284,8 @@ fn INTEGRATION_CPU_does_not_branch_on_beq() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(30);
 
@@ -307,8 +307,8 @@ fn INTEGRATION_CPU_preserves_flags_on_bit() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(30);
 
@@ -328,8 +328,8 @@ fn INTEGRATION_CPU_bmi_branches_on_sign_bit_set() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(30);
 
@@ -349,8 +349,8 @@ fn INTEGRATION_CPU_bne_branches_on_zero_clear() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(50);
 
@@ -370,8 +370,8 @@ fn INTEGRATION_CPU_bpl_branches_on_sign_clear() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(50);
 
@@ -391,8 +391,8 @@ fn INTEGRATION_CPU_bpl_does_not_branch_on_sign_set() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(50);
 
@@ -416,8 +416,8 @@ fn INTEGRATION_CPU_cmp_does_branch_on_accumulator_less_than_memory_bcc() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(50);
 
@@ -440,8 +440,8 @@ fn INTEGRATION_CPU_cmp_does_branch_on_accumulator_greater_than_memory_bcs() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(50);
 
@@ -464,8 +464,8 @@ fn INTEGRATION_CPU_cmp_does_branch_on_accumulator_less_than_equal_to_bcc() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(50);
 
@@ -483,8 +483,8 @@ fn INTEGRATION_CPU_dec_decrements() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(3);
 
@@ -506,8 +506,8 @@ fn INTEGRATION_CPU_dex_decrements() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(20);
 
@@ -532,8 +532,8 @@ fn INTEGRATION_CPU_jsr_rts_combination_works() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, 0xC000).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, 0xC000).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(20);
 
@@ -558,8 +558,8 @@ fn INTEGRATION_CPU_jsr_rts_combination_works_when_code_segment_loaded_at_weird_a
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, 0xABCD).unwrap();
-    cpu.load(&bytecode[..], 0xABCD);  // Load it at a weird address
+    let segments = assembler.assemble_string(asm, 0xABCD).unwrap();
+    cpu.load(&segments[0].code[..], 0xABCD);  // Load it at a weird address
 
     cpu.step_n(20);
 
@@ -582,8 +582,8 @@ fn INTEGRATION_CPU_lsr_can_halve_a_number() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(20);
 
@@ -601,8 +601,8 @@ fn INTEGRATION_CPU_ora_ors_against_accumulator() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(10);
 
@@ -621,8 +621,8 @@ fn INTEGRATION_CPU_pha_pla() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(3);
 
@@ -647,8 +647,8 @@ fn INTEGRATION_CPU_rol() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(3);
 
@@ -670,8 +670,8 @@ fn INTEGRATION_CPU_ror() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(3);
 
@@ -688,8 +688,8 @@ fn INTEGRATION_CPU_brk_rti() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     // Force set some flags first
     cpu.flags.carry = true;
@@ -716,8 +716,8 @@ fn INTEGRATION_CPU_sbc() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(2);
 
@@ -735,8 +735,8 @@ fn INTEGRATION_CPU_sbc_with_decimal_mode() {
     let mut cpu = rs6502::Cpu::new();
     let mut assembler = rs6502::Assembler::new();
 
-    let bytecode = assembler.assemble_string(asm, None).unwrap();
-    cpu.load(&bytecode[..], None);
+    let segments = assembler.assemble_string(asm, None).unwrap();
+    cpu.load(&segments[0].code[..], None);
 
     cpu.step_n(3);
 


### PR DESCRIPTION
Adds support for an `.ORG` directive to the assembler which enables spreading code across memory pages.

This changes the `Assembler::assemble` function signature in a significant way. It now returns a `Result<Vec<CodeSegment>, AssemblerError>`, where a `CodeSegment` is structured:

```
pub struct CodeSegment {
    pub address: u16,
    pub code: Vec<u8>
}
```

Thus it is now up to the consumer to load the returned `CodeSegment` instances at their respective offsets in memory.