### PR TITLE
Interrupt handlers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs6502"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Simon Whitehead <chemnova@gmail.com>"]
 repository = "https://github.com/simon-whitehead/rs6502"
 description = "A 6502 Microprocessor tool suite. Includes a Disassembler, Assembler and Emulator."

--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -93,10 +93,6 @@ impl Cpu {
         }
     }
 
-    pub fn get_code(&self) -> &[u8] {
-        &self.memory[self.code_start..self.code_start + self.code_size]
-    }
-
     /// Runs N instructions of code through the Cpu
     pub fn step_n(&mut self, n: u32) -> CpuMultiStepResult {
         let mut v = 0;

--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -30,8 +30,6 @@ pub struct Cpu {
     pub registers: Registers,
     pub flags: StatusFlags,
     pub stack: Stack,
-    code_start: usize,
-    code_size: usize,
 }
 
 pub type CpuLoadResult = Result<(), CpuError>;
@@ -46,8 +44,6 @@ impl Cpu {
             registers: Registers::new(),
             flags: Default::default(),
             stack: Stack::new(),
-            code_start: DEFAULT_CODE_SEGMENT_START_ADDRESS as usize,
-            code_size: 0,
         }
     }
 
@@ -79,8 +75,6 @@ impl Cpu {
         // start address of the code segment
         self.set_start_vector(addr);
 
-        self.code_start = addr as usize;
-        self.code_size = code.len();
 
         Ok(())
     }

--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -685,8 +685,8 @@ impl Cpu {
     fn rti(&mut self) {
         let mem = &mut self.memory[STACK_START..STACK_END + 0x01];
 
-        let value = self.stack.pop(mem).unwrap();
-        let pc = self.stack.pop_u16(mem).unwrap();
+        let value = self.stack.pop(mem).expect("ERR: Returning from an interrupt with an empty stack. Did you forget to set the interrupt handler address?");
+        let pc = self.stack.pop_u16(mem).expect("ERR: Returning from an interrupt with an empty stack. Did you forget to set the interrupt handler address?");
 
         self.flags = value.into();
         self.registers.PC = pc;

--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -415,12 +415,8 @@ impl Cpu {
     }
 
     fn brk(&mut self) {
-        let mut mem = &mut self.memory[STACK_START..STACK_END + 0x01];
-
-        self.stack.push_u16(mem, self.registers.PC);
-        self.stack.push(mem, self.flags.to_u8());
-
-        self.flags.interrupt_disabled = true;
+        // Just call the IRQ handler - they're the same thing
+        self.irq();
     }
 
     fn bvc(&mut self, operand: &Operand) {

--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -95,17 +95,10 @@ impl Cpu {
     pub fn step_n(&mut self, n: u32) -> CpuMultiStepResult {
         let mut v = 0;
         for _ in 0..n {
-            if self.finished() {
-                break;
-            }
             v += self.step()? as u64;
         }
 
         Ok(v)
-    }
-
-    pub fn finished(&self) -> bool {
-        self.registers.PC > self.code_start as u16 + self.code_size as u16 - 1
     }
 
     pub fn reset(&mut self) {

--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -75,7 +75,6 @@ impl Cpu {
         // start address of the code segment
         self.set_start_vector(addr);
 
-
         Ok(())
     }
 

--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -13,7 +13,7 @@ const DEFAULT_CODE_SEGMENT_START_ADDRESS: u16 = 0xC000;  // Default to a 16KB RO
 const STACK_START: usize = 0x100;
 const STACK_END: usize = 0x1FF;
 
-const RESET_VECTOR: usize: 0xFFFC;
+const RESET_VECTOR: usize = 0xFFFC;
 const NMI_VECTOR: usize = 0xFFFA;
 const IRQ_VECTOR: usize = 0xFFFE;
 

--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -8,7 +8,7 @@ use cpu::memory_bus::MemoryBus;
 use cpu::registers::Registers;
 use cpu::stack::Stack;
 
-const DEFAULT_CODE_SEGMENT_START_ADDRESS: u16 = 0xC000;  // Default to a 16KB ROM, leaving 32KB of main memory
+const DEFAULT_CODE_SEGMENT_START_ADDRESS: u16 = 0xC000;  // Default to a 16KB ROM, leaving 48KB of main memory
 
 const STACK_START: usize = 0x100;
 const STACK_END: usize = 0x1FF;

--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -243,6 +243,11 @@ impl Cpu {
     pub fn nmi(&mut self) {
         // Always handle an NMI
         let handler_addr = LittleEndian::read_u16(&self.memory[NMI_VECTOR..]);
+
+        // ..unless its not set to something other than zero:
+        if handler_addr == 0 {
+            return;
+        }
         let mem = &mut self.memory[STACK_START..STACK_END + 0x01];
 
         self.stack.push_u16(mem, self.registers.PC);
@@ -260,6 +265,12 @@ impl Cpu {
         }
 
         let handler_addr = LittleEndian::read_u16(&self.memory[IRQ_VECTOR..]);
+
+        // ..unless its not set to something other than zero:
+        if handler_addr == 0 {
+            return;
+        }
+
         let mem = &mut self.memory[STACK_START..STACK_END + 0x01];
 
         self.stack.push_u16(mem, self.registers.PC);

--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -13,6 +13,9 @@ const DEFAULT_CODE_SEGMENT_START_ADDRESS: u16 = 0xC000;  // Default to a 16KB RO
 const STACK_START: usize = 0x100;
 const STACK_END: usize = 0x1FF;
 
+const NMI_POINTER: usize = 0xFFFA;
+const IRQ_POINTER: usize = 0xFFFE;
+
 #[derive(Debug)]
 pub enum Operand {
     Immediate(u8),
@@ -58,6 +61,8 @@ impl Cpu {
             let addr = addr.unwrap();
             if addr as u32 + code.len() as u32 > u16::max_value() as u32 {
                 return Err(CpuError::code_segment_out_of_range(addr));
+            } else if addr == 0 {
+                DEFAULT_CODE_SEGMENT_START_ADDRESS
             } else {
                 addr
             }
@@ -241,6 +246,36 @@ impl Cpu {
             Operand::Memory(addr) => addr,
             Operand::Implied => 0,
         }
+    }
+
+    /// Execute the Non-Maskable Interrupt handler. This ignores the interrupt
+    /// flag and forces execution to the NMI
+    pub fn nmi(&mut self) {
+        // Always handle an NMI
+        let handler_addr = LittleEndian::read_u16(&self.memory[NMI_POINTER..]);
+        let mem = &mut self.memory[STACK_START..STACK_END + 0x01];
+
+        self.stack.push_u16(mem, self.registers.PC);
+        self.stack.push(mem, self.flags.to_u8());
+        self.flags.interrupt_disabled = true;
+        self.registers.PC = handler_addr;
+    }
+
+    /// Execute the Interrupt ReQuest handler if we currently are accepting
+    /// maskable interrupts. Ignore it otherwise.
+    pub fn irq(&mut self) {
+        // If interrupts are disabled, don't worry about this
+        if self.flags.interrupt_disabled {
+            return;
+        }
+
+        let handler_addr = LittleEndian::read_u16(&self.memory[IRQ_POINTER..]);
+        let mem = &mut self.memory[STACK_START..STACK_END + 0x01];
+
+        self.stack.push_u16(mem, self.registers.PC);
+        self.stack.push(mem, self.flags.to_u8());
+        self.flags.interrupt_disabled = true;
+        self.registers.PC = handler_addr;
     }
 
     // ## OpCode handlers ##
@@ -654,7 +689,10 @@ impl Cpu {
         let mem = &mut self.memory[STACK_START..STACK_END + 0x01];
 
         let value = self.stack.pop(mem).unwrap();
+        let pc = self.stack.pop_u16(mem).unwrap();
+
         self.flags = value.into();
+        self.registers.PC = pc;
     }
 
     fn sbc(&mut self, operand: &Operand) {

--- a/src/cpu/cpu.rs
+++ b/src/cpu/cpu.rs
@@ -109,6 +109,8 @@ impl Cpu {
     }
 
     pub fn reset(&mut self) {
+        self.registers = Default::default();
+        self.flags = Default::default();
         self.registers.PC = LittleEndian::read_u16(&self.memory[0xFFFC..]);
     }
 

--- a/src/cpu/registers.rs
+++ b/src/cpu/registers.rs
@@ -9,6 +9,12 @@ pub struct Registers {
 
 impl Registers {
     pub fn new() -> Registers {
+        Registers { ..Default::default() }
+    }
+}
+
+impl Default for Registers {
+    fn default() -> Registers {
         Registers {
             A: 0,
             X: 0,

--- a/src/cpu/stack.rs
+++ b/src/cpu/stack.rs
@@ -39,7 +39,7 @@ impl Stack {
     }
 
     pub fn push_u16(&mut self, stack_area: &mut [u8], val: u16) -> StackPushResult {
-        if self.pointer > 0x01 {
+        if self.pointer >= 0x01 {
             LittleEndian::write_u16(&mut stack_area[self.pointer - 0x01..], val);
             self.pointer -= 0x02;
 
@@ -61,7 +61,7 @@ impl Stack {
     }
 
     pub fn pop_u16(&mut self, stack_area: &mut [u8]) -> StackPopResult<u16> {
-        if self.pointer < 0xFE {
+        if self.pointer <= 0xFE {
             self.pointer += 0x01;
             let result = LittleEndian::read_u16(&stack_area[self.pointer..]);
             self.pointer += 0x01;

--- a/tests/cpu.rs
+++ b/tests/cpu.rs
@@ -368,19 +368,6 @@ mod tests {
         }
 
         #[test]
-        fn brk_does_store_pc_and_status_flags_on_stack() {
-            let code = vec![0xA9, 0x0E, 0x00];
-            let mut cpu = Cpu::new();
-            cpu.load(&code[..], None);
-            cpu.reset();
-
-            cpu.step_n(10);
-
-            assert_eq!(0xC0, cpu.memory[0x1FF]);
-            assert_eq!(0x03, cpu.memory[0x1FE]);
-        }
-
-        #[test]
         fn bvc_does_not_jump_on_overflow_set() {
             let code = vec![0xA9, 0x7F, 0x69, 0x01, 0x50, 0x03, 0xA9, 0xFF];
             let mut cpu = Cpu::new();

--- a/tests/cpu.rs
+++ b/tests/cpu.rs
@@ -18,9 +18,10 @@ mod tests {
             let fake_code = vec![0x0A, 0x0B, 0x0C, 0x0D];
             let mut cpu = Cpu::new();
             cpu.load(&fake_code[..], None);
+            cpu.reset();
 
             let memory_sum: u32 = cpu.memory.iter().map(|n| *n as u32).sum();
-            assert_eq!(46, memory_sum);
+            assert_eq!(46 + 0x00C0, memory_sum);
         }
 
         #[test]
@@ -28,6 +29,7 @@ mod tests {
             let fake_code = vec![0x0A, 0x0B, 0x0C, 0x0D];
             let mut cpu = Cpu::new();
             cpu.load(&fake_code[..], None);
+            cpu.reset();
 
             assert_eq!(0x0D, cpu.memory.read_byte(0xC003));
             assert_eq!(0x0C, cpu.memory.read_byte(0xC002));
@@ -40,6 +42,7 @@ mod tests {
             let fake_code = vec![0x0A, 0x0B, 0x0C, 0x0D];
             let mut cpu = Cpu::new();
             cpu.load(&fake_code[..], 0xF000);
+            cpu.reset();
 
             assert_eq!(0x0D, cpu.memory.read_byte(0xF003));
             assert_eq!(0x0C, cpu.memory.read_byte(0xF002));
@@ -52,6 +55,7 @@ mod tests {
             let fake_code = vec![0x0A, 0x0B, 0x0C, 0x0D];
             let mut cpu = Cpu::new();
             let load_result = cpu.load(&fake_code[..], 0xFFFD);
+            cpu.reset();
 
             assert_eq!(Err(CpuError::code_segment_out_of_range(0xFFFD)),
                        load_result);
@@ -62,6 +66,7 @@ mod tests {
             let fake_code = vec![0xC3];
             let mut cpu = Cpu::new();
             cpu.load(&fake_code[..], None);
+            cpu.reset();
             let step_result: CpuStepResult = cpu.step();
 
             assert_eq!(Err(CpuError::unknown_opcode(0xC000, 0xC3)), step_result);// This is the unofficial DCP (d,X) opcode
@@ -72,6 +77,7 @@ mod tests {
             let fake_code = vec![0xC3];
             let mut cpu = Cpu::new();
             cpu.load(&fake_code[..], None);
+            cpu.reset();
             let step_result: CpuStepResult = cpu.step();
         }
 
@@ -80,6 +86,7 @@ mod tests {
             let code = vec![0xF8];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step();
 
@@ -91,6 +98,7 @@ mod tests {
             let code = vec![0xD8];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step();
 
@@ -102,6 +110,7 @@ mod tests {
             let code = vec![0xA9, 0x05, 0x69, 0x03];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(2);
 
@@ -113,6 +122,7 @@ mod tests {
             let code = vec![0xA9, 0xFD, 0x69, 0x05];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(2);
 
@@ -125,6 +135,7 @@ mod tests {
             let code = vec![0xF8, 0xA9, 0x05, 0x69, 0x05];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(3);
 
@@ -137,6 +148,7 @@ mod tests {
             let code = vec![0xF8, 0xA9, 0x95, 0x69, 0x10];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(3);
 
@@ -150,6 +162,7 @@ mod tests {
             let code = vec![0xA9, 0x20, 0x8D, 0x00, 0x20];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(2);
 
@@ -163,6 +176,7 @@ mod tests {
             let code = vec![0xA9, 0xFF, 0x29, 0x0F];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(2);
 
@@ -176,6 +190,7 @@ mod tests {
             let code = vec![0xA9, 0x02, 0x0A];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(2);
 
@@ -188,6 +203,7 @@ mod tests {
             let code = vec![0xA9, 0x02, 0x0A];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(2);
 
@@ -200,6 +216,7 @@ mod tests {
             let code = vec![0xA9, 0x80, 0x0A];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(2);
 
@@ -212,6 +229,7 @@ mod tests {
             let code = vec![0xA9, 0xFE, 0x69, 0x01, 0x90, 0x03, 0xA9, 0x00];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(3);
 
@@ -225,6 +243,7 @@ mod tests {
             let code = vec![0xA9, 0xF0, 0x69, 0x01, 0x90, 0xFC];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(50);
 
@@ -236,6 +255,7 @@ mod tests {
             let code = vec![0xA9, 0xFF, 0x69, 0x01, 0xB0, 0x03, 0xA9, 0xAA];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(10);
 
@@ -248,6 +268,7 @@ mod tests {
             let code = vec![0xA9, 0xF0, 0x69, 0x10, 0xF0, 0x03, 0xA9, 0xAA];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(10);
 
@@ -259,6 +280,7 @@ mod tests {
             let code = vec![0xA9, 0xF0, 0x24, 0x00];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(10);
 
@@ -271,6 +293,7 @@ mod tests {
             let code = vec![0xA9, 0xF0, 0x85, 0x44, 0x24, 0x44];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(10);
 
@@ -285,6 +308,7 @@ mod tests {
             let code = vec![0xA9, 0x7F, 0x69, 0x01, 0x30, 0x03, 0xA9, 0x00];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(10);
 
@@ -297,6 +321,7 @@ mod tests {
             let code = vec![0xA9, 0xFE, 0x69, 0x01, 0xD0, 0x03, 0xA9, 0xAA];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(10);
 
@@ -309,6 +334,7 @@ mod tests {
             let code = vec![0xA9, 0xFF, 0x69, 0x01, 0xD0, 0x03, 0xA9, 0xAA];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(10);
 
@@ -320,6 +346,7 @@ mod tests {
             let code = vec![0xA9, 0xFE, 0x10, 0x03, 0xA9, 0xF3];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(10);
 
@@ -332,6 +359,7 @@ mod tests {
             let code = vec![0xA9, 0x0E, 0x10, 0x03, 0xA9, 0xF3];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(10);
 
@@ -344,6 +372,7 @@ mod tests {
             let code = vec![0xA9, 0x0E, 0x00];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(10);
 
@@ -356,6 +385,7 @@ mod tests {
             let code = vec![0xA9, 0x7F, 0x69, 0x01, 0x50, 0x03, 0xA9, 0xFF];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(10);
 
@@ -368,6 +398,7 @@ mod tests {
             let code = vec![0xA9, 0x7E, 0x69, 0x01, 0x50, 0x03, 0xA9, 0xFF];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(10);
 
@@ -380,6 +411,7 @@ mod tests {
             let code = vec![0xA9, 0x7E, 0x69, 0x01, 0x70, 0x03, 0xA9, 0xFF];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(10);
 
@@ -392,6 +424,7 @@ mod tests {
             let code = vec![0xA9, 0x7F, 0x69, 0x01, 0x70, 0x03, 0xA9, 0xFF];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(10);
 
@@ -404,6 +437,7 @@ mod tests {
             let code = vec![0x18];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
             cpu.flags.carry = true;
 
             cpu.step();
@@ -416,6 +450,7 @@ mod tests {
             let code = vec![0xD8];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
             cpu.flags.decimal = true;
 
             cpu.step();
@@ -428,6 +463,7 @@ mod tests {
             let code = vec![0x58];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
             cpu.flags.interrupt_disabled = true;
 
             cpu.step();
@@ -440,6 +476,7 @@ mod tests {
             let code = vec![0xB8];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
             cpu.flags.overflow = true;
 
             cpu.step();
@@ -452,6 +489,7 @@ mod tests {
             let code = vec![0xA9, 0x55, 0xC9, 0x55];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
             cpu.flags.zero = false;
 
             cpu.step_n(2);
@@ -464,6 +502,7 @@ mod tests {
             let code = vec![0xA9, 0x55, 0xC9, 0x65];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
             cpu.flags.carry = true;
 
             cpu.step_n(2);
@@ -476,6 +515,7 @@ mod tests {
             let code = vec![0xA9, 0x65, 0xC9, 0x55];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
             cpu.flags.carry = false;
 
             cpu.step_n(2);
@@ -488,6 +528,7 @@ mod tests {
             let code = vec![0xA2, 0x55, 0xE0, 0x65];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
             cpu.flags.carry = true;
 
             cpu.step_n(2);
@@ -500,6 +541,7 @@ mod tests {
             let code = vec![0xA2, 0x65, 0xE0, 0x55];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
             cpu.flags.carry = false;
 
             cpu.step_n(2);
@@ -512,6 +554,7 @@ mod tests {
             let code = vec![0xA0, 0x55, 0xC0, 0x65];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
             cpu.flags.carry = true;
 
             cpu.step_n(2);
@@ -524,6 +567,7 @@ mod tests {
             let code = vec![0xA0, 0x65, 0xC0, 0x55];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
             cpu.flags.carry = false;
 
             cpu.step_n(2);
@@ -536,6 +580,7 @@ mod tests {
             let code = vec![0xA9, 0x55, 0x85, 0x85, 0xC6, 0x85];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(10);
 
@@ -547,6 +592,7 @@ mod tests {
             let code = vec![0xA2, 0x55, 0xCA];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(10);
 
@@ -558,6 +604,7 @@ mod tests {
             let code = vec![0xA0, 0x55, 0x88];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(10);
 
@@ -569,6 +616,7 @@ mod tests {
             let code = vec![0xA9, 0x00, 0x49, 0x80];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(2);
 
@@ -580,6 +628,7 @@ mod tests {
             let code = vec![0xA9, 0x55, 0x85, 0x85, 0xE6, 0x85];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(10);
 
@@ -591,6 +640,7 @@ mod tests {
             let code = vec![0xA2, 0x55, 0xE8];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(10);
 
@@ -602,6 +652,7 @@ mod tests {
             let code = vec![0xA0, 0x55, 0xC8];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(20);
 
@@ -613,6 +664,7 @@ mod tests {
             let code = vec![0xA9, 0x55, 0x4C, 0x07, 0x00, 0xA9, 0xFF];
             let mut cpu = Cpu::new();
             cpu.load(&code[..], None);
+            cpu.reset();
 
             cpu.step_n(2);
 

--- a/tests/cpu_integration.rs
+++ b/tests/cpu_integration.rs
@@ -13,6 +13,7 @@ fn INTEGRATION_CPU_can_add_basic_numbers_in_accumulator() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(2);
 
@@ -32,6 +33,7 @@ fn INTEGRATION_CPU_can_add_binary_coded_decimal_numbers_in_accumulator() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(3);
 
@@ -50,6 +52,7 @@ fn INTEGRATION_CPU_can_add_mixed_mode_numbers_in_accumulator() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(2);
 
@@ -70,6 +73,7 @@ fn INTEGRATION_CPU_can_store_bytes_in_memory() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(4);
 
@@ -92,6 +96,7 @@ fn INTEGRATION_CPU_can_overwrite_own_memory() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(4);
 
@@ -112,6 +117,7 @@ fn INTEGRATION_CPU_can_load_byte_into_memory_and_logical_AND_it_with_A_register(
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(4);
 
@@ -135,6 +141,7 @@ fn INTEGRATION_CPU_can_load_byte_into_memory_and_logical_AND_it_with_A_register_
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(4);
 
@@ -156,6 +163,7 @@ fn INTEGRATION_CPU_does_not_branch_on_clear_carry_flag() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(3);
 
@@ -177,6 +185,7 @@ fn INTEGRATION_CPU_can_branch_on_carry_flag() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(4);
 
@@ -203,6 +212,7 @@ fn INTEGRATION_CPU_can_branch_on_carry_flag_to_correct_offset() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(5);
 
@@ -223,6 +233,7 @@ fn INTEGRATION_CPU_can_loop_on_bcc() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(30);
 
@@ -244,6 +255,7 @@ fn INTEGRATION_CPU_can_branch_on_bcs() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(30);
 
@@ -265,6 +277,7 @@ fn INTEGRATION_CPU_can_branch_on_beq() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(30);
 
@@ -286,6 +299,7 @@ fn INTEGRATION_CPU_does_not_branch_on_beq() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(30);
 
@@ -309,6 +323,7 @@ fn INTEGRATION_CPU_preserves_flags_on_bit() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(30);
 
@@ -330,6 +345,7 @@ fn INTEGRATION_CPU_bmi_branches_on_sign_bit_set() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(30);
 
@@ -351,6 +367,7 @@ fn INTEGRATION_CPU_bne_branches_on_zero_clear() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(50);
 
@@ -372,6 +389,7 @@ fn INTEGRATION_CPU_bpl_branches_on_sign_clear() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(50);
 
@@ -393,6 +411,7 @@ fn INTEGRATION_CPU_bpl_does_not_branch_on_sign_set() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(50);
 
@@ -418,6 +437,7 @@ fn INTEGRATION_CPU_cmp_does_branch_on_accumulator_less_than_memory_bcc() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(50);
 
@@ -442,6 +462,7 @@ fn INTEGRATION_CPU_cmp_does_branch_on_accumulator_greater_than_memory_bcs() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(50);
 
@@ -466,6 +487,7 @@ fn INTEGRATION_CPU_cmp_does_branch_on_accumulator_less_than_equal_to_bcc() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(50);
 
@@ -485,6 +507,7 @@ fn INTEGRATION_CPU_dec_decrements() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(3);
 
@@ -508,6 +531,7 @@ fn INTEGRATION_CPU_dex_decrements() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(20);
 
@@ -534,6 +558,7 @@ fn INTEGRATION_CPU_jsr_rts_combination_works() {
 
     let segments = assembler.assemble_string(asm, 0xC000).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(20);
 
@@ -560,6 +585,7 @@ fn INTEGRATION_CPU_jsr_rts_combination_works_when_code_segment_loaded_at_weird_a
 
     let segments = assembler.assemble_string(asm, 0xABCD).unwrap();
     cpu.load(&segments[0].code[..], 0xABCD);  // Load it at a weird address
+    cpu.reset();
 
     cpu.step_n(20);
 
@@ -584,6 +610,7 @@ fn INTEGRATION_CPU_lsr_can_halve_a_number() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(20);
 
@@ -603,6 +630,7 @@ fn INTEGRATION_CPU_ora_ors_against_accumulator() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(10);
 
@@ -623,6 +651,7 @@ fn INTEGRATION_CPU_pha_pla() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(3);
 
@@ -649,6 +678,7 @@ fn INTEGRATION_CPU_rol() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(3);
 
@@ -672,6 +702,7 @@ fn INTEGRATION_CPU_ror() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(3);
 
@@ -690,6 +721,7 @@ fn INTEGRATION_CPU_brk_rti() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     // Force set some flags first
     cpu.flags.carry = true;
@@ -718,6 +750,7 @@ fn INTEGRATION_CPU_sbc() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(2);
 
@@ -737,6 +770,7 @@ fn INTEGRATION_CPU_sbc_with_decimal_mode() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.reset();
 
     cpu.step_n(3);
 
@@ -762,6 +796,7 @@ fn INTEGRATION_CPU_can_load_code_segments_at_offsets() {
     for segment in segments {
         cpu.load(&segment.code[..], segment.address);
     }
+    cpu.reset();
 
     assert_eq!(&[0xA9, 0x35, 0x8D, 0x00, 0x40], &cpu.memory[0x2000..0x2005]);
     assert_eq!(&[0xA9, 0x00, 0x8D, 0x00, 0x01], &cpu.memory[0xABCD..0xABD2]);

--- a/tests/cpu_integration.rs
+++ b/tests/cpu_integration.rs
@@ -712,7 +712,11 @@ fn INTEGRATION_CPU_ror() {
 #[test]
 fn INTEGRATION_CPU_brk_rti() {
     let asm = "
+        LDX #$20
+        STX $FFFF
         BRK
+
+    .ORG $2000
         RTI
     ";
 
@@ -721,13 +725,15 @@ fn INTEGRATION_CPU_brk_rti() {
 
     let segments = assembler.assemble_string(asm, None).unwrap();
     cpu.load(&segments[0].code[..], None);
+    cpu.load(&segments[1].code[..], segments[1].address);
     cpu.reset();
+    cpu.flags.interrupt_disabled = false;
 
     // Force set some flags first
     cpu.flags.carry = true;
     cpu.flags.decimal = true;
 
-    cpu.step(); // Push them to the stack
+    cpu.step_n(3); // Push them to the stack
 
     cpu.flags.carry = false;
     cpu.flags.decimal = false;


### PR DESCRIPTION
This PR adds support for interrupt handlers.

[According to online sources](https://en.wikipedia.org/wiki/Interrupts_in_65xx_processors), the 6502 has 3 interrupt types it accepts.

This PR introduces:

* `Cpu.nmi()`, which __always__ suspends execution and loads the interrupt handler for non-maskable interrupts from `0xFFFA`.
* `Cpu.irq()`, which suspends execution and loads the interrupt handler for maskable interrupts from `0xFFFE` __only if interrupts are not disabled via the `SEI` instruction__.
* `Cpu.reset()`, which loads the program counter from `0xFFFC` and resets all the Cpu flags and registers.